### PR TITLE
fix: Deprecated PHP 8.2 warning in buffer

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://jruns.github.io//
 Tags: performance, defer, delay
 Requires at least: 6.0
 Tested up to: 6.8.2
-Stable tag: 0.5.0
+Stable tag: 0.5.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/includes/class-wp-utilities-html-buffer.php
+++ b/includes/class-wp-utilities-html-buffer.php
@@ -25,7 +25,7 @@ class Wp_Utilities_Html_Buffer {
 	}
 
 	public function start_buffer() {
-		ob_start( array( 'self', 'filter_buffer' ) );
+		ob_start( array( Wp_Utilities_Html_Buffer::class, 'filter_buffer' ) );
 	}
 
 	public function end_buffer() {

--- a/includes/class-wp-utilities.php
+++ b/includes/class-wp-utilities.php
@@ -161,6 +161,11 @@ class Wp_Utilities {
 	 * Load enabled utilities
 	 */
 	private function load_utilities() {
+		// Only activate utilites on the frontend
+		if ( is_admin() ) {
+			return;
+		}
+
 		$utilities_dir = dirname( __FILE__ ) . '/utilities/';
 
 		if ( is_dir( $utilities_dir ) ) {

--- a/wp-utilities.php
+++ b/wp-utilities.php
@@ -14,7 +14,7 @@
  * Plugin Name:       WP Performance Utilities 
  * Plugin URI:        https://github.com/jruns/wp-utilities
  * Description:       Utilities to improve the performance of your WordPress site.
- * Version:           0.5.0
+ * Version:           0.5.1
  * Author:            Jason Schramm
  * Author URI:        https://jruns.github.io/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'WP_UTILITIES_VERSION', '0.5.0' );
+define( 'WP_UTILITIES_VERSION', '0.5.1' );
 define( 'WP_UTILITIES_BASE_NAME', plugin_basename( __FILE__ ) );
 
 /**


### PR DESCRIPTION
- Fix deprecated warning in PHP 8.2
- Only run utilities code on the frontend (not in wp-admin)